### PR TITLE
Don't return headers if we are skipping rows for headRow.

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,7 +91,7 @@ Name | Type | Default | Description
 --- | :---: | :---: | ---
 headRow | `number` | `1` | The row number of head. (Start from 1)
 valueRowStart | `number` | `2` | The start row number of values. (Start from 1)
-startColumn | `number` | `A` | The start column Char of values. (Start from A)
+startColumn | `string` | `A` | The start column Char of values. (Start from A)
 trace | `Boolean` | `false` | Whether to log each file path while convert success.
 
 

--- a/index.js
+++ b/index.js
@@ -34,16 +34,22 @@ var getHeaders = function(worksheet, headRow, startColumn) {
         var row = +match[2]; // 1234
         var col = match[1]; // ABCD
 
-        if (row !== headRow) {
-            return headers;
+        // If we've read past the header row, there is nothing else we're
+        // going to do, so return the headers we've found.
+        if (row > headRow) {
+            break;
         }
 
+        // If we aren't at the header row, then move to the next one.
+        if (row < headRow) {
+            continue;
+        }
+
+        // Pull in the data from the column, if we are in the right one.
         if (col >= startColumn) {
-            if (row === headRow) {
-                var tmp = {};
-                tmp[key] = cell.v;
-                headers.push(tmp);
-            }
+            var tmp = {};
+            tmp[key] = cell.v;
+            headers.push(tmp);
         }
     }
 


### PR DESCRIPTION
Salutations, I found a problem where I was skipping the first four rows of an Excel file. Because of a `!==` check that returns the headers, it was not reading the header information correctly.

- Changed the logic to not return headers if the row doesn't match to breaking out of the loop after the row exceeds the header row.
- Modified the header processing to skip rows before `headRow` row.
- Corrected documentation where `startColumn` is an Excel-like string, not a number.